### PR TITLE
Remove .nfo file provisioning in auviousrecordplay plugin

### DIFF
--- a/plugins/janus_auviousrecordplay.c
+++ b/plugins/janus_auviousrecordplay.c
@@ -1221,17 +1221,6 @@ static void janus_auviousrecordplay_hangup_media_internal(janus_plugin_session *
 	}
 	session->vrc = NULL;
 	janus_mutex_unlock(&session->rec_mutex);
-	if(session->recorder) {
-		if(session->recording) {
-			g_atomic_int_set(&session->recording->completed, 1);
-			/* Generate the offer */
-			if(janus_auviousrecordplay_generate_offer(session->recording) < 0) {
-				JANUS_LOG(LOG_WARN, "Could not generate offer for recording %"SCNu64"...\n", session->recording->id);
-			}
-		} else {
-			JANUS_LOG(LOG_WARN, "Got a stop but missing recorder/recording!\n");
-		}
-	}
 	if(session->recording) {
 		janus_auviousrecordplay_recordings_remove(session->recording);
 		janus_refcount_decrease(&session->recording->ref);

--- a/plugins/janus_auviousrecordplay.c
+++ b/plugins/janus_auviousrecordplay.c
@@ -1899,7 +1899,7 @@ recadone:
 			json_decref(jsep);
 		}
 		janus_auviousrecordplay_message_free(msg);
-		JANUS_LOG(LOG_INFO, "  >> Listed recordings: %u\n", g_hash_table_size(recordings));
+		JANUS_LOG(LOG_VERB, "  >> Listed recordings: %u\n", g_hash_table_size(recordings));
 		continue;
 error:
 		{

--- a/plugins/janus_auviousrecordplay.c
+++ b/plugins/janus_auviousrecordplay.c
@@ -1899,7 +1899,7 @@ recadone:
 			json_decref(jsep);
 		}
 		janus_auviousrecordplay_message_free(msg);
-        JANUS_LOG(LOG_INFO, "  >> Listed recordings: %u\n", g_hash_table_size(recordings));
+		JANUS_LOG(LOG_INFO, "  >> Listed recordings: %u\n", g_hash_table_size(recordings));
 		continue;
 error:
 		{


### PR DESCRIPTION
This pull request removes the provisioning of .nfo files within the auviousrecordplay plugin. The primary reasons for this change are as follows:

1. **Redundancy with Recorder Service**: The auvious system handles recording metadata through a dedicated recorder service. The existence of .nfo file generation within the plugin created unnecessary redundancy.

2. **Memory Usage Concerns**: With an accumulation of recordings over time, the creation and management of .nfo files could lead to unnecessary memory usage. 

3. **Potential for Erroneous Behavior**: In scenarios where the Janus container was restarted, the plugin would attempt to reload all previous .nfo files and their associated recording files. This behavior could introduce errors, especially if the external recorder service's state did not align with the contents of the .nfo files, in addition to redundant memory usage.

By removing the .nfo file provisioning logic, we aim to streamline the operation of the auviousrecordplay plugin, ensuring that it works more efficiently and reliably, particularly in production environments where resource optimization is critical.
